### PR TITLE
Added bean-discovery-mode="all" to beans.xml.

### DIFF
--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+         version="1.1" bean-discovery-mode="all">
+
+</beans>


### PR DESCRIPTION
This is a workaround to a WELD 2.2.X bug. Some user may want to upgrade
 the current "suggested" version (2.1.2), and it will help them avoid
 wasting time. See https://issues.jboss.org/browse/WELD-2071

Note that this plugin will still be scanned as "explicit bean-archive"
 by the container, as defined by the specs at
 http://docs.jboss.org/cdi/spec/1.1/cdi-spec.html#bean_archive.
